### PR TITLE
add visit_Str to support obj.object_type == 'vehicle.car'

### DIFF
--- a/apperception/utils/fn_to_sql.py
+++ b/apperception/utils/fn_to_sql.py
@@ -129,6 +129,9 @@ class GenSqlVisitor(ast.NodeVisitor):
     def generic_visit(self, node: ast.AST) -> None:
         raise Exception("Unsupported node type: " + type(node).__name__)
 
+    def visit_Str(self, node: ast.Str) -> str:
+        return "'{}'".format(node.s)
+
     def visit_Lambda(self, node: ast.Lambda) -> str:
         args = [arg.arg for arg in node.args.args]
         if len(args) != len(self.tables):


### PR DESCRIPTION
Currently, when running `fig-10.ipynb`, it will throw an exception when parsing `lambda obj: obj.object_type == 'vehicle.car'`

```
Traceback (most recent call last):
  File "benchmarks/scenic_equivelants/fig-10.py", line 28, in <module>
    key_1 = world_1.get_traj_key()
  File "./apperception/new_world.py", line 192, in get_traj_key
    )._execute_from_root(QueryType.TRAJ)
  File "./apperception/new_world.py", line 334, in _execute_from_root
    query = node._execute(query=query)
  File "./apperception/new_world.py", line 349, in _execute
    return fn(**{**self._kwargs, **kwargs})
  File "./apperception/new_db.py", line 242, in filter
    predicate_sql = fn_to_sql(predicate, tables_sql)
  File "./apperception/utils/fn_to_sql.py", line 29, in fn_to_sql
    body = ast.parse(predicate).body
  File "./apperception/utils/fn_to_sql.py", line 129, in visit
    return super().visit(node)
  File "/home/jimlin7777/miniconda3/envs/capstone2/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "./apperception/utils/fn_to_sql.py", line 141, in visit_Lambda
    return self.visit(node.body)
  File "./apperception/utils/fn_to_sql.py", line 129, in visit
    return super().visit(node)
  File "/home/jimlin7777/miniconda3/envs/capstone2/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "./apperception/utils/fn_to_sql.py", line 164, in visit_Compare
    right = self.visit(node.comparators[0])
  File "./apperception/utils/fn_to_sql.py", line 129, in visit
    return super().visit(node)
  File "/home/jimlin7777/miniconda3/envs/capstone2/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "./apperception/utils/fn_to_sql.py", line 132, in generic_visit
    raise Exception("Unsupported node type: " + type(node).__name__)
Exception: Unsupported node type: Str
```

Adding a proper `visit_Str` should be able to fix this problem