### PR TITLE
Add miss track count

### DIFF
--- a/optimized_ingestion/stages/detection_estimation/__init__.py
+++ b/optimized_ingestion/stages/detection_estimation/__init__.py
@@ -82,7 +82,8 @@ class DetectionEstimation(Stage[DetectionEstimationMetadatum]):
             else:
                 action_type_counts[next_action_type] += 1
             next_frame_num = next_sample_plan.get_next_frame_num(next_frame_num)
-            metadata.append(all_detection_info)
+            # metadata.append(all_detection_info)
+            metadata.append(next_sample_plan)
 
         # TODO: ignore the last frame ->
         metadata.append([])

--- a/optimized_ingestion/stages/tracking_2d/strongsort.py
+++ b/optimized_ingestion/stages/tracking_2d/strongsort.py
@@ -8,6 +8,7 @@ from yolo_tracker.yolov5.utils.torch_utils import select_device
 from ...cache import cache
 from ..decode_frame.decode_frame import DecodeFrame
 from ..detection_2d.detection_2d import Detection2D
+from ..detection_estimation import DetectionEstimation
 from .tracking_2d import Tracking2D, Tracking2DResult
 
 if TYPE_CHECKING:
@@ -31,6 +32,8 @@ class StrongSORT(Tracking2D):
         detections = Detection2D.get(payload)
         assert detections is not None
 
+        sample_plans = DetectionEstimation.get(payload)
+
         images = DecodeFrame.get(payload)
         assert images is not None
         metadata: "List[Dict[int, Tracking2DResult]]" = []
@@ -39,15 +42,16 @@ class StrongSORT(Tracking2D):
         strongsort = create_tracker('strongsort', reid_weights, device, False)
         assert isinstance(strongsort, _StrongSORT)
         curr_frame, prev_frame = None, None
+        miss_track_count = 0
         with torch.no_grad():
             # ss_benchmark: "list[list[float]]" = []
             if hasattr(strongsort, 'model'):
                 if hasattr(strongsort.model, 'warmup'):
                     strongsort.model.warmup()
 
-            assert len(detections) == len(images)
+            assert len(detections) == len(images) == len(sample_plans)
             # for idx, ((det, names, dids), im0s) in tqdm(enumerate(zip(detections, images)), total=len(images)):
-            for idx, ((det, names, dids), im0s) in enumerate(zip(detections, images)):
+            for idx, ((det, names, dids), im0s, sample_plan) in enumerate(zip(detections, images, sample_plans)):
                 if not payload.keep[idx] or len(det) == 0:
                     metadata.append({})
                     strongsort.increment_ages()
@@ -67,6 +71,9 @@ class StrongSORT(Tracking2D):
 
                 confs = det[:, 4]
                 output_ = strongsort.update(det.cpu(), im0)
+                target_did = None
+                if sample_plan and sample_plan.action:
+                    target_did = sample_plan.action.target_obj_id
 
                 # frame_benchmark.extend(_t)
                 # frame_benchmark.append(time.time())
@@ -92,6 +99,8 @@ class StrongSORT(Tracking2D):
                             names[cls],
                             conf.item(),
                         )
+                        if obj_id not in trajectories and target_did and did == target_did:
+                            miss_track_count += 1
                         if obj_id not in trajectories:
                             trajectories[obj_id] = []
                         trajectories[obj_id].append(labels[obj_id])
@@ -113,7 +122,11 @@ class StrongSORT(Tracking2D):
             # # for s in ss_benchmark:
             # #     print(s)
             # self.ss_benchmarks.append(ss_benchmark)
-
+        with open("./outputs/miss_count.txt", "r") as f:
+            total_miss_count = int(f.read().strip())
+            total_miss_count += miss_track_count
+        with open("./outputs/miss_count.txt", "w") as f:
+            f.write(str(total_miss_count))
         for trajectory in trajectories.values():
             for before, after in zip(trajectory[:-1], trajectory[1:]):
                 before.next = after


### PR DESCRIPTION
### Intent
When computing the sample plan, the algorithm has added the target object id that dominates the generation of the sample plan:
https://github.com/apperception-db/apperception/blob/9650c67a0bc1b1caf70a5059157c6a447d3a0c16/optimized_ingestion/stages/detection_estimation/sample_plan_algorithms.py#L43

`target_object_id` means that this object would be the first likely object to disappear from the view of the ego camera. Then we can track if the skipping miss the track of this target object. We don't need to track other objects because the target object is the only one that we know sould be in the frame. For other objects, even if they should be, we can't make the claim that they are the same objects.

### Discussion
The only problem is that if the sample action is ego_exit_segment, then we can't find if we lose the track or not. A bench mark is run to see how many ego_exit_segment actions we have.